### PR TITLE
NUTCH-1999 Add /robots.txt to Nutch site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,7 @@ Paginate = 4
 unsafe = true # allow raw HTML in markdown content
 
 [Params]
+  siteBaseURL = "https://nutch.apache.org"
   RSSLink = "/index.xml"
   author = "Apache Nutch Project Management Committee"
   github = "https://github.com/apache/nutch"
@@ -41,3 +42,4 @@ unsafe = true # allow raw HTML in markdown content
     name = "Apache"
     weight = -100
     url = "/apache/"
+

--- a/content/robots.txt
+++ b/content/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/content/robots.txt
+++ b/content/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://nutch.apache.org/sitemap.xml

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,0 +1,10 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url/>
+  {{ range .Data.Pages }}{{ if ne .Params.sitemapExclude true }}
+    <url>{{ $url := urls.Parse .Permalink }}
+      <loc>{{ .Site.Params.SiteBaseURL }}{{ $url.Path }}</loc>{{ if not .Lastmod.IsZero }}
+      <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
+    </url>{{ end }}{{ end }}
+</urlset>


### PR DESCRIPTION
Adds a trivial robots.txt to the Nutch site. We can complete it later by adding a sitemap link etc.