### PR TITLE
NUTCH-3166 Create a security page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,23 +21,27 @@ unsafe = true # allow raw HTML in markdown content
 
 [[menu.main]]
     name = "Community"
-    weight = -100
+    weight = -106
     url = "/community/"
 [[menu.main]]
     name = "Development"
-    weight = -100
+    weight = -105
     url = "/development/"
 [[menu.main]]
+    name = "Security"
+    weight = -104
+    url = "/documentation/security"
+[[menu.main]]
     name = "Docs"
-    weight = -100
+    weight = -103
     url = "/documentation/"
 [[menu.main]]
     name = "Download"
-    weight = -100
+    weight = -102
     url = "/download/"    
 [[menu.main]]
     name = "News"
-    weight = -100
+    weight = -101
     url = "/news/"
 [[menu.main]]
     name = "The Apache Software Foundation"

--- a/content/apache.md
+++ b/content/apache.md
@@ -9,7 +9,7 @@ bref = ""
 
 * Visit the [Apache Software Foundation Homepage](https://apache.org)
 * Information about the [Apache Licenses](https://www.apache.org/licenses/)
-* The [Apache Security Team](https://www.apache.org/security/)
+* The [Apache Security Team](https://www.apache.org/security/).<br/>Please also visit our [Security page](/documentation/security).
 * The [Apache Software Foundation Sponsorship Program](https://www.apache.org/foundation/sponsorship.html)
 * [Sponsors and Thanks](https://www.apache.org/foundation/thanks.html)
 * [ASF Privacy Policies](https://privacy.apache.org/policies/privacy-policy-public.html)

--- a/content/documentation/security.md
+++ b/content/documentation/security.md
@@ -34,9 +34,9 @@ Nutch can be run on a local instance or on a Hadoop cluster. For both runtimes, 
 
 #### Nutch Server and REST API
 
-The Nutch REST API is not protected by authentication or authorization. It must not be publicly available. Access should only be granted to trusted users. Granting access to the REST API is equivalent to granting access to the instance where the service is running. This includes permissions to write to the local filesystem and run any Java class available on the service's class path.
+Nutch releases which packaged the legacy JAX-RS Nutch service/server/REST API did not provide any authentication and/or authorization. Therefore the service must not be publicly available. Access should only be granted to trusted users. Granting access to the service is equivalent to granting access to the instance where the service is running. This includes permissions to write to the local filesystem and run any Java class available on the service's class path.
 
-Please also note that the Nutch server resp. all classes in the package `org.apache.nutch.service` are deprecated and will be removed in an upcoming Nutch release.
+The legacy JAX-RS Nutch service was removed in Nutch 1.23.
 
 #### Information Leakage
 

--- a/content/documentation/security.md
+++ b/content/documentation/security.md
@@ -8,7 +8,7 @@ bref = ""
 
 +++
 
-## Reporting Security Issues of Apache Nutch
+### Reporting Security Issues of Apache Nutch
 
 The Apache Software Foundation is very active in eliminating security problems and denial-of-service attacks against its products.
 
@@ -18,7 +18,7 @@ Please note that the security mailing list is intended solely for reporting undi
 
 The private security mailing address is: security@apache.org
 
-## Security Model
+### Security Model
 
 Apache Nutch is designed to operate in trusted environments, either locally or on a Hadoop cluster.
 
@@ -50,15 +50,29 @@ Measures to prevent information leakage include:
 
 An attacker may place arbitrary links on pages visited by the crawler, for example a link to `file:///etc/passwd`. The crawler configuration must ensure that such links are not followed.
 
-## Security-Related Questions
+### Security-Related Questions
 
 If you have security-related questions, please contact the Nutch team over the [dev](mailto:dev@nutch.apache.org) or [user](mailto:user@nutch.apache.org) mailing list. See [Mailing Lists](/community/mailing-lists/) for more information.
 
-## Known Security Vulnerabilities
+### Known Security Vulnerabilities
 
 The following security vulnerabilities are known:
 - See the section about the [Nutch Server and REST API](#nutch-server-and-rest-api).
 
-## Nutch CVE List
+### Nutch CVE List
 
-tbd.
+#### [CVE-2021-23901](https://nvd.nist.gov/vuln/detail/CVE-2021-23901)
+
+Type: XXE injection<br/>
+Affects Nutch version (up to): 1.17<br/>
+Fixed Nutch version: 1.18<br/>
+Publicly announced on [2021-01-24](https://lists.apache.org/thread/y1onyktyk5cbz3nofor1goko177hh2vt)<br/>
+Reporter / Thanks To: Martin Heyden
+
+#### [CVE-2016-6809](https://nvd.nist.gov/vuln/detail/CVE-2016-6809)
+Type: deserialization of untrusted data<br/>
+Affects Nutch version (up to): 2.3.1<br/>
+Fixed Nutch version: 2.4<br/>
+Publicly announced on [2019-10-15](https://lists.apache.org/thread/9knfvy04nvtzpdfh5cng3f7421y7fo46)<br/>
+Reporter / Thanks To: Pierre Ernst<br/>
+

--- a/content/documentation/security.md
+++ b/content/documentation/security.md
@@ -1,0 +1,64 @@
++++
+title = "Security"
+description = "Reporting Nutch security issues and an explanation of the Nutch security model"
+weight = 10
+draft = false
+toc = true
+bref = ""
+
++++
+
+## Reporting Security Issues of Apache Nutch
+
+The Apache Software Foundation is very active in eliminating security problems and denial-of-service attacks against its products.
+
+We strongly encourage people to report security issues privately via the [ASF Security Team](https://www.apache.org/security/)'s mailing list before disclosing them publicly.
+
+Please note that the security mailing list is intended solely for reporting undisclosed security vulnerabilities and managing the process of fixing them. We cannot accept regular bug reports or other queries at this address. Any email sent to this address that does not relate to an undisclosed security vulnerability in the Nutch source code will be ignored.
+
+The private security mailing address is: security@apache.org
+
+## Security Model
+
+Apache Nutch is designed to operate in trusted environments, either locally or on a Hadoop cluster.
+
+This section outlines the security model and key security considerations. Understanding how to use and deploy Nutch in a secure manner is mandatory.
+
+#### Trusted Configuration
+
+The configuration files used by Nutch are loaded during job execution. These files are treated as a trusted source and must not involve any user-supplied input at runtime.
+
+#### Nutch Runtime
+
+Nutch can be run on a local instance or on a Hadoop cluster. For both runtimes, it is mandatory that access to the runtime must be restricted to trusted users. Securing the Nutch runtime is essential. For information on securing a Hadoop cluster, please refer to the [Apache Hadoop security page](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SecureMode.html).
+
+#### Nutch Server and REST API
+
+The Nutch REST API is not protected by authentication or authorization. It must not be publicly available. Access should only be granted to trusted users. Granting access to the REST API is equivalent to granting access to the instance where the service is running. This includes permissions to write to the local filesystem and run any Java class available on the service's class path.
+
+Please also note that the Nutch server resp. all classes in the package `org.apache.nutch.service` are deprecated and will be removed in an upcoming Nutch release.
+
+#### Information Leakage
+
+By default, Nutch is configured to "crawl" the local file system and intranet resources. Feeding an intranet search is a common use case for Nutch. Additionally, Nutch can crawl web sites that require authorization. If the crawled data is exposed to the public, whether as a search index or in any other data formats (e.g., WARC files), it is mandatory to ensure that no private resources are included in the given crawl.
+
+Measures to prevent information leakage include:
+
+* Disabling access to the local file system (disable the "protocol-file" plugin).
+* Maintaining restrictive URL filters.
+* Enabling IP address filters to prevent access to private IP address ranges.
+
+An attacker may place arbitrary links on pages visited by the crawler, for example a link to `file:///etc/passwd`. The crawler configuration must ensure that such links are not followed.
+
+## Security-Related Questions
+
+If you have security-related questions, please contact the Nutch team over the [dev](mailto:dev@nutch.apache.org) or [user](mailto:user@nutch.apache.org) mailing list. See [Mailing Lists](/community/mailing-lists/) for more information.
+
+## Known Security Vulnerabilities
+
+The following security vulnerabilities are known:
+- See the section about the [Nutch Server and REST API](#nutch-server-and-rest-api).
+
+## Nutch CVE List
+
+tbd.


### PR DESCRIPTION
Adds a security page and links it from the header and also from the documentation page.

TODO:
- [done] fill the section of known CVEs
- deploy the site

Credits: the [StormCrawler security page](https://stormcrawler.apache.org/security/) has been used as an excellent starting point.